### PR TITLE
Fix background service worker module registration

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -12,7 +12,8 @@
 	"https://dblp.org/"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_scripts": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
 	"https://dblp.org/"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_scripts": [
     {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,7 +1,7 @@
 // background.ts
 // Canonical citation graph pipeline that merges evidence from OpenAlex and OpenCitations.
 
-import { ApiResponse } from './types';
+import type { ApiResponse } from './types';
 
 type ProviderName = 'openalex' | 'opencitations';
 
@@ -374,5 +374,3 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   }
   return false;
 });
-
-export {};


### PR DESCRIPTION
## Summary
- mark the background service worker as an ES module in the manifest to match the compiled script
- clean up the TypeScript background file to avoid unnecessary exports

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694117f41768832999fdd8f5e20d26c9)